### PR TITLE
Remove readr dependency in clean_raw_text_file()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: fdadata
 Title: Access US FDA Data
-Version: 0.0.0.9003
+Version: 0.0.0.9004
 Authors@R: 
     person(given = "Brendan",
            family = "O'Leary",

--- a/R/clean_raw_text_file.R
+++ b/R/clean_raw_text_file.R
@@ -7,7 +7,7 @@
 clean_raw_text_file <- function(filepath) {
   message("Cleaning string from ", filepath, sep = "")
   cleaner_string <- readLines(filepath, skipNul = TRUE)
-  cleaner_string <- gsub("\"", "", readr::read_lines(cleaner_string, skip = 1))
+  cleaner_string <- gsub("\"", "", cleaner_string[-1])
   # Remove carriage return, keep line feed
   cleaner_string <-
     stringr::str_remove_all(


### PR DESCRIPTION
It had a tendency to interpret the vector as one of filenames rather than as a raw text string.